### PR TITLE
Aaron Olsen

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -4,7 +4,6 @@
     <title>My Awesome Style Editor</title>
     <link rel="stylesheet" type="text/css" href="main.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
-    <script src="styleEditor.js"></script>
   </head>
   <body>
     <div class="container">
@@ -36,12 +35,12 @@
           <h3>Hobbies</h3>
           <p>Portland taxidermy lomo raw denim beard. Everyday carry scenester pinterest, dreamcatcher migas skateboard prism lyft. Drinking vinegar +1 live-edge disrupt, brunch knausgaard celiac shabby chic mixtape semiotics.</p>
           <p>Food truck seitan normcore plaid, meh 8-bit prism hashtag vape. Vice typewriter celiac chillwave brunch, fixie 8-bit listicle microdosing. Ramps snackwave mustache edison bulb PBR&B prism photo booth. Listicle venmo normcore enamel pin 90's, semiotics brooklyn gentrify kombucha kickstarter.</p>
-          <p>Deep v sustainable cardigan austin, put a bird on it bitters offal fingerstache master cleanse. Meggings semiotics green juice, 8-bit banjo trust fund forage selvage cold-pressed gluten-free authentic microdosing pickled. Hashtag banh mi blue bottle, chicharrones chartreuse kitsch forage microdosing vape.</p> 
+          <p>Deep v sustainable cardigan austin, put a bird on it bitters offal fingerstache master cleanse. Meggings semiotics green juice, 8-bit banjo trust fund forage selvage cold-pressed gluten-free authentic microdosing pickled. Hashtag banh mi blue bottle, chicharrones chartreuse kitsch forage microdosing vape.</p>
           <p>Sustainable pok pok ennui forage bespoke subway tile. Microdosing cray pitchfork, schlitz woke vegan salvia irony sustainable locavore. Raw denim meggings ugh brooklyn chia, blog YOLO iceland master cleanse cardigan coloring book authentic thundercats craft beer. Kombucha poke shoreditch, vaporware freegan yuccie small batch gluten-free migas meditation chia pok pok pabst ennui offal.</p>
         </section>
         <section>
           <h3>Experiences</h3>
-          <p>Kinfolk vinyl deep v, shoreditch single-origin coffee ramps flannel brooklyn tote bag street art pok pok. Aesthetic iPhone 8-bit, +1 migas street art next level brooklyn fanny pack williamsburg gluten-free. Drinking vinegar offal seitan stumptown chartreuse artisan enamel pin flannel, gluten-free prism hell of 8-bit retro gentrify pork belly.</p> 
+          <p>Kinfolk vinyl deep v, shoreditch single-origin coffee ramps flannel brooklyn tote bag street art pok pok. Aesthetic iPhone 8-bit, +1 migas street art next level brooklyn fanny pack williamsburg gluten-free. Drinking vinegar offal seitan stumptown chartreuse artisan enamel pin flannel, gluten-free prism hell of 8-bit retro gentrify pork belly.</p>
           <p>Sustainable sartorial vinyl craft beer distillery. Poke lomo air plant, edison bulb pinterest vice listicle 3 wolf moon. Slow-carb lo-fi DIY, 8-bit coloring book semiotics chicharrones green juice snackwave blue bottle next level. +1 succulents cronut cliche, banjo XOXO intelligentsia hot chicken mumblecore williamsburg wayfarers church-key flexitarian 8-bit.</p>
         </section>
       </div>
@@ -50,4 +49,5 @@
       </div>
     </div>
   </body>
+  <script src="styleEditor.js"></script>
 </html>

--- a/source/styleEditor.js
+++ b/source/styleEditor.js
@@ -1,3 +1,16 @@
 $(document).ready(function(){
-  // your code goes here.
+
+  $('#style_editor').on('submit', function(){
+
+    let selector = this.selector.value;
+    let property = this.property.value;
+    let value = this.value.value;
+
+    changeElements(selector, property, value);
+  });
+
+  function changeElements(selector, property, value){
+    event.preventDefault();
+    $(selector).css(property, value);
+  };
 });


### PR DESCRIPTION
Css can be modified through style_editor field
- This was easier than I thought, which is why this is my first git ci
- style_editor form listens for submit.
- Values from child inputs are used to build jQuery function altering
css of selectors. User must input . or # to make successful selection.
- preventDefault is used to keep page rendering default css values.
Otherwise changes to css would revert back to original values. Now those
properties and values will stack until page is refreshed.